### PR TITLE
feat(frequencies): add support for QuasiDistribution type

### DIFF
--- a/pr_toolbox/quantum/results/__init__.py
+++ b/pr_toolbox/quantum/results/__init__.py
@@ -10,14 +10,14 @@
 
 """Results tools."""
 
-from .frequencies import bitflip_counts, bitmask_counts, map_counts
+from .frequencies import bitflip_frequencies, bitmask_frequencies, map_frequencies
 from .reckoning import CanonicalReckoner, ExpvalReckoner, ReckoningResult
 
 __all__ = [
     "ReckoningResult",
     "ExpvalReckoner",
     "CanonicalReckoner",
-    "map_counts",
-    "bitflip_counts",
-    "bitmask_counts",
+    "map_frequencies",
+    "bitflip_frequencies",
+    "bitmask_frequencies",
 ]

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -70,7 +70,7 @@ def map_dict(frequencies: dict, mapper) -> dict:
 
 
 @map_frequencies.register
-def map_counts(counts: Counts, mapper) -> Counts:
+def map_counts(counts: Counts, mapper: Callable) -> Counts:
     """Map counts by reassigning keys according to input callable.
 
     Args:

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -26,8 +26,6 @@ FrequenciesLike = Union[Counts, QuasiDistribution]
 ################################################################################
 ## FREQUENCIES
 ################################################################################
-
-
 @singledispatch
 def map_frequencies(
     frequencies: FrequenciesLike | dict, mapper: Callable
@@ -133,8 +131,10 @@ def bitmask_frequencies(frequencies: FrequenciesLike, bitmask: int) -> Frequenci
 
 def counts_to_quasi_dists(counts: Counts) -> QuasiDistribution:
     """Infers a :class:`~qiskit.result.QuasiDistribution` from :class:`~qiskit.result.Counts`.
+
     Args:
         counts: the counts to convert.
+
     Returns:
         New QuasiDistribution inferred from counts.
     """

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -13,7 +13,6 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable
 from functools import singledispatch
 from typing import Union
 
@@ -26,23 +25,42 @@ FrequenciesLike = Union[Counts, QuasiDistribution]
 ################################################################################
 ## FREQUENCIES
 ################################################################################
+
+
 @singledispatch
-def map_frequencies(
-    frequencies: FrequenciesLike | dict, mapper: Callable
-) -> FrequenciesLike | dict:
+def map_frequencies(frequencies: FrequenciesLike | dict, mapper) -> FrequenciesLike:
     """Map frequencies by reassigning keys according to input callable.
 
     Args:
         frequencies: the frequencies to process.
-        mapper: the callable to map readout bits (i.e. counts keys).
+        mapper: the callable to map readout bits (i.e. frequencies keys).
 
     Returns:
         New frequencies with readout bits mapped according to input callable.
     """
-    if not isinstance(frequencies, (Counts, QuasiDistribution, dict)):
+    raise TypeError(
+        f"Invalid frequencies type. Expected `Counts` or `QuasiDistribution` or `dict'"
+        f" but got {type(frequencies)} instead."
+    )
+
+
+@map_frequencies.register
+def map_dict(frequencies: dict, mapper) -> dict:
+    """Map frequency dictionary by reassigning keys according to input callable.
+
+    Args:
+        frequencies: the frequency dictionary to process.
+        mapper: the callable to map readout bits (i.e. frequencies keys).
+
+    Returns:
+        New frequency dictionary with readout bits mapped according to input callable.
+    """
+    if not all(isinstance(k, int) for k in frequencies.keys()):
+        raise TypeError("Invalid key types for frequencies. Keys must be of type `int'.")
+
+    if not all(isinstance(v, (int, float)) for v in frequencies.values()):
         raise TypeError(
-            f"Invalid frequencies type. Expected `Counts` or `QuasiDistribution` or `dict'"
-            f" but got {type(frequencies)} instead."
+            "Invalid value types for frequencies. Values must be of type `int' or `float'."
         )
 
     frequencies_dict: dict[int, int | float] = defaultdict(lambda: 0)
@@ -52,8 +70,8 @@ def map_frequencies(
     return frequencies_dict
 
 
-@map_frequencies.register(Counts)
-def map_counts(counts: Counts, mapper: Callable) -> Counts:
+@map_frequencies.register
+def map_counts(counts: Counts, mapper) -> Counts:
     """Map counts by reassigning keys according to input callable.
 
     Args:
@@ -63,24 +81,26 @@ def map_counts(counts: Counts, mapper: Callable) -> Counts:
     Returns:
         New counts with readout bits mapped according to input callable.
     """
-    counts_dict: dict[int, int] = map_frequencies(counts.int_outcomes(), mapper)
-    return Counts(counts_dict)
+    frequencies: dict = counts.int_outcomes()
+    frequencies = map_frequencies(frequencies, mapper)
+    return Counts(frequencies)
 
 
-@map_frequencies.register(QuasiDistribution)
-def map_quasi_dists(quasi_dists: QuasiDistribution, mapper: Callable) -> QuasiDistribution:
+@map_frequencies.register
+def map_quasi_dist(quasi_dist: QuasiDistribution, mapper) -> QuasiDistribution:
     """Map quasi-distributions by reassigning keys according to input callable.
 
     Args:
-        quasi_dists: the quasi-distributions to process.
-        mapper: the callable to map readout bits (i.e. counts keys).
+        quasi_dist: the quasi-distributions to process.
+        mapper: the callable to map readout bits (i.e. quasi_dist keys).
 
     Returns:
         New QuasiDistribution with readout bits mapped according to input callable.
     """
-    quasi_dists_dict: dict[int, float] = map_frequencies(dict(quasi_dists), mapper)
+    frequencies: dict = dict(quasi_dist)
+    frequencies = map_frequencies(frequencies, mapper)
     return QuasiDistribution(
-        quasi_dists_dict, shots=quasi_dists.shots, stddev_upper_bound=quasi_dists.stddev_upper_bound
+        frequencies, shots=quasi_dist.shots, stddev_upper_bound=quasi_dist.stddev_upper_bound
     )
 
 

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -15,50 +15,71 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable
 
-from qiskit.result import Counts
+from numpy import sqrt
+from qiskit.result import QuasiDistribution, Counts
+
+FrequenciesLike = Counts | QuasiDistribution
 
 
 ################################################################################
-## COUNTS
+## FREQUENCIES
 ################################################################################
-def map_counts(counts: Counts, mapper: Callable) -> Counts:
-    """Map counts by reassigning keys according to input callable.
+def map_frequencies(frequencies: FrequenciesLike, mapper: Callable) -> FrequenciesLike:
+    """Map frequencies by reassigning keys according to input callable.
 
     Args:
-        counts: the counts to process.
+        frequencies: the frequencies to process.
         mapper: the callable to map readout bits (i.e. counts keys).
 
     Returns:
-        New counts with readout bits mapped according to input callable.
+        New frequencies with readout bits mapped according to input callable.
     """
-    counts_dict: dict[int, int] = defaultdict(lambda: 0)
-    for readout, freq in counts.int_outcomes().items():
+    frequencies_dict: dict[int, int | float] = defaultdict(lambda: 0)
+    frequency_type = type(frequencies)
+    if isinstance(frequencies, Counts):
+        frequencies = frequencies.int_outcomes()
+    for readout, freq in frequencies.items():
         readout = mapper(readout)
-        counts_dict[readout] += freq
-    return Counts(counts_dict)
+        frequencies_dict[readout] += freq
+    return frequency_type(frequencies_dict)
 
 
-def bitflip_counts(counts: Counts, bitflips: int) -> Counts:
-    """Flip readout bits in counts according to the input bitflips (int encoded).
+def bitflip_frequencies(frequencies: QuasiDistribution | Counts, bitflips: int) -> QuasiDistribution:
+    """Flip readout bits in frequencies according to the input bitflips (int encoded).
 
     Args:
-        counts: the counts to process.
+        frequencies: the frequencies to process.
         bitflips: the bitflips to be applied.
 
     Returns:
-        New counts with readout bits flipped according to input.
+        New frequencies with readout bits flipped according to input.
     """
-    return map_counts(counts, lambda readout: readout ^ bitflips)
+    return map_frequencies(frequencies, lambda readout: readout ^ bitflips)
 
 
-def bitmask_counts(counts: Counts, bitmask: int) -> Counts:
-    """Apply mask to readout bits in counts.
+def bitmask_frequencies(frequencies: QuasiDistribution | Counts, bitmask: int) -> QuasiDistribution:
+    """Apply mask to readout bits in frequencies.
 
     Args:
-        counts: the counts to process.
+        frequencies: the frequencies to process.
         bitmask: the bit mask to be applied.
 
     Returns:
         New counts with readout bits masked according to input.
     """
-    return map_counts(counts, lambda readout: readout & bitmask)
+    return map_frequencies(frequencies, lambda readout: readout & bitmask)
+
+
+def convert_counts_to_quasi_dists(counts: Counts) -> QuasiDistribution:
+    """Infers a :class:`~qiskit.result.QuasiDistribution` from :class:`~qiskit.result.Counts`.
+
+    Args:
+        counts: the counts to convert.
+
+    Returns:
+        New QuasiDistribution inferred from counts.
+    """
+    shots = counts.shots()
+    std_dev = sqrt(1 / shots) if shots else None
+    probabilities = {k: v / (shots or 1) for k, v in counts.int_outcomes().items()}
+    return QuasiDistribution(probabilities, shots=shots, stddev_upper_bound=std_dev)

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Callable
 from functools import singledispatch
 from typing import Union
 

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -29,7 +29,9 @@ FrequenciesLike = Union[Counts, QuasiDistribution]
 
 
 @singledispatch
-def map_frequencies(frequencies: FrequenciesLike | dict, mapper) -> FrequenciesLike:
+def map_frequencies(
+    frequencies: FrequenciesLike | dict, mapper: Callable
+) -> FrequenciesLike | dict:
     """Map frequencies by reassigning keys according to input callable.
 
     Args:

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -103,7 +103,7 @@ def bitmask_frequencies(frequencies: FrequenciesLike, bitmask: int) -> Frequenci
         bitmask: the bit mask to be applied.
 
     Returns:
-        New counts with readout bits masked according to input.
+        New frequencies with readout bits masked according to input.
     """
     return map_frequencies(frequencies, lambda readout: readout & bitmask)
 

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -86,7 +86,7 @@ def map_counts(counts: Counts, mapper: Callable) -> Counts:
 
 
 @map_frequencies.register
-def map_quasi_dist(quasi_dist: QuasiDistribution, mapper) -> QuasiDistribution:
+def map_quasi_dist(quasi_dist: QuasiDistribution, mapper: Callable) -> QuasiDistribution:
     """Map quasi-distributions by reassigning keys according to input callable.
 
     Args:

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -79,9 +79,7 @@ def map_quasi_dists(quasi_dists: QuasiDistribution, mapper: Callable) -> QuasiDi
     )
 
 
-def bitflip_frequencies(
-    frequencies: QuasiDistribution | Counts, bitflips: int
-) -> QuasiDistribution:
+def bitflip_frequencies(frequencies: FrequenciesLike, bitflips: int) -> FrequenciesLike:
     """Flip readout bits in frequencies according to the input bitflips (int encoded).
 
     Args:
@@ -94,7 +92,7 @@ def bitflip_frequencies(
     return map_frequencies(frequencies, lambda readout: readout ^ bitflips)
 
 
-def bitmask_frequencies(frequencies: QuasiDistribution | Counts, bitmask: int) -> QuasiDistribution:
+def bitmask_frequencies(frequencies: FrequenciesLike, bitmask: int) -> FrequenciesLike:
     """Apply mask to readout bits in frequencies.
 
     Args:

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -61,7 +61,6 @@ def map_dict(frequencies: dict, mapper) -> dict:
         raise TypeError(
             "Invalid value types for frequencies. Values must be of type `int' or `float'."
         )
-
     frequencies_dict: dict[int, int | float] = defaultdict(lambda: 0)
     for readout, freq in frequencies.items():
         readout = mapper(readout)

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -40,7 +40,10 @@ def map_frequencies(frequencies: FrequenciesLike, mapper: Callable) -> Frequenci
         return map_counts(frequencies, mapper)
     if isinstance(frequencies, QuasiDistribution):
         return map_quasi_dists(frequencies, mapper)
-    raise TypeError("Frequencies of type (Counts, QuasiDistribution) are expected for mapping.")
+    raise TypeError(
+        f"Invalid frequencies type. Expected `Counts` or `QuasiDistribution`"
+        f" but got {type(frequencies)} instead."
+    )
 
 
 def map_counts(counts: Counts, mapper: Callable) -> Counts:
@@ -70,12 +73,12 @@ def map_quasi_dists(quasi_dists: QuasiDistribution, mapper: Callable) -> QuasiDi
     Returns:
         New QuasiDistribution with readout bits mapped according to input callable.
     """
-    counts_dict: dict[int, float] = defaultdict(lambda: 0)
+    frequencies_dict: dict[int, float] = defaultdict(lambda: 0)
     for readout, freq in quasi_dists.items():
         readout = mapper(readout)
-        counts_dict[readout] += freq
+        frequencies_dict[readout] += freq
     return QuasiDistribution(
-        counts_dict, shots=quasi_dists.shots, stddev_upper_bound=quasi_dists.stddev_upper_bound
+        frequencies_dict, shots=quasi_dists.shots, stddev_upper_bound=quasi_dists.stddev_upper_bound
     )
 
 

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -57,7 +57,6 @@ def map_dict(frequencies: dict, mapper) -> dict:
     """
     if not all(isinstance(k, int) for k in frequencies.keys()):
         raise TypeError("Invalid key types for frequencies. Keys must be of type `int'.")
-
     if not all(isinstance(v, (int, float)) for v in frequencies.values()):
         raise TypeError(
             "Invalid value types for frequencies. Values must be of type `int' or `float'."

--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -14,11 +14,12 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable
+from typing import Union
 
 from numpy import sqrt
-from qiskit.result import QuasiDistribution, Counts
+from qiskit.result import Counts, QuasiDistribution
 
-FrequenciesLike = Counts | QuasiDistribution
+FrequenciesLike = Union[Counts, QuasiDistribution]
 
 
 ################################################################################
@@ -34,17 +35,53 @@ def map_frequencies(frequencies: FrequenciesLike, mapper: Callable) -> Frequenci
     Returns:
         New frequencies with readout bits mapped according to input callable.
     """
-    frequencies_dict: dict[int, int | float] = defaultdict(lambda: 0)
-    frequency_type = type(frequencies)
+
     if isinstance(frequencies, Counts):
-        frequencies = frequencies.int_outcomes()
-    for readout, freq in frequencies.items():
+        return map_counts(frequencies, mapper)
+    if isinstance(frequencies, QuasiDistribution):
+        return map_quasi_dists(frequencies, mapper)
+    raise TypeError("Frequencies of type (Counts, QuasiDistribution) are expected for mapping.")
+
+
+def map_counts(counts: Counts, mapper: Callable) -> Counts:
+    """Map counts by reassigning keys according to input callable.
+
+    Args:
+        counts: the counts to process.
+        mapper: the callable to map readout bits (i.e. counts keys).
+
+    Returns:
+        New counts with readout bits mapped according to input callable.
+    """
+    counts_dict: dict[int, int] = defaultdict(lambda: 0)
+    for readout, freq in counts.int_outcomes().items():
         readout = mapper(readout)
-        frequencies_dict[readout] += freq
-    return frequency_type(frequencies_dict)
+        counts_dict[readout] += freq
+    return Counts(counts_dict)
 
 
-def bitflip_frequencies(frequencies: QuasiDistribution | Counts, bitflips: int) -> QuasiDistribution:
+def map_quasi_dists(quasi_dists: QuasiDistribution, mapper: Callable) -> QuasiDistribution:
+    """Map quasi-distributions by reassigning keys according to input callable.
+
+    Args:
+        quasi_dists: the quasi-distributions to process.
+        mapper: the callable to map readout bits (i.e. counts keys).
+
+    Returns:
+        New QuasiDistribution with readout bits mapped according to input callable.
+    """
+    counts_dict: dict[int, float] = defaultdict(lambda: 0)
+    for readout, freq in quasi_dists.items():
+        readout = mapper(readout)
+        counts_dict[readout] += freq
+    return QuasiDistribution(
+        counts_dict, shots=quasi_dists.shots, stddev_upper_bound=quasi_dists.stddev_upper_bound
+    )
+
+
+def bitflip_frequencies(
+    frequencies: QuasiDistribution | Counts, bitflips: int
+) -> QuasiDistribution:
     """Flip readout bits in frequencies according to the input bitflips (int encoded).
 
     Args:

--- a/pr_toolbox/quantum/results/reckoning.py
+++ b/pr_toolbox/quantum/results/reckoning.py
@@ -27,7 +27,7 @@ from qiskit.result import Counts
 from pr_toolbox.binary import parity_bit
 from pr_toolbox.quantum.operators import pauli_integer_mask
 
-from .frequencies import bitmask_counts
+from .frequencies import bitmask_frequencies
 
 ReckoningResult = namedtuple("ReckoningResult", ("expval", "std_error"))
 OperatorType = Union[BaseOperator, PauliSumOp, str]  # TODO: to types
@@ -166,7 +166,7 @@ class ExpvalReckoner(ABC):
     @abstractmethod
     def _reckon_pauli(self, counts: Counts, pauli: Pauli) -> ReckoningResult:
         mask = pauli_integer_mask(pauli)
-        counts = bitmask_counts(counts, mask)
+        counts = bitmask_frequencies(counts, mask)
         coeff = (-1j) ** pauli.phase
         expval, std_error = self._reckon_counts(counts)
         return ReckoningResult(coeff * expval, std_error)

--- a/test/unit/quantum/results/test_frequencies.py
+++ b/test/unit/quantum/results/test_frequencies.py
@@ -80,70 +80,61 @@ class TestBitflipFrequencies:
     """Test bitflip frequencies."""
 
     @mark.parametrize(
-        "frequency_type, frequencies, bitflips, expected",
+        "frequencies, bitflips, expected",
         [
-            (Counts, {0b00: 0, 0b01: 1}, 0b00, {0b00: 0, 0b01: 1}),
-            (Counts, {0b00: 0, 0b01: 1}, 0b01, {0b00: 1, 0b01: 0}),
-            (Counts, {0b00: 0, 0b01: 1}, 0b10, {0b10: 0, 0b11: 1}),
-            (Counts, {0b00: 0, 0b01: 1}, 0b11, {0b10: 1, 0b11: 0}),
+            (Counts({0b00: 0, 0b01: 1}), 0b00, {0b00: 0, 0b01: 1}),
+            (Counts({0b00: 0, 0b01: 1}), 0b01, {0b00: 1, 0b01: 0}),
+            (Counts({0b00: 0, 0b01: 1}), 0b10, {0b10: 0, 0b11: 1}),
+            (Counts({0b00: 0, 0b01: 1}), 0b11, {0b10: 1, 0b11: 0}),
             (
-                Counts,
-                {0b00: 0, 0b01: 1, 0b10: 2, 0b11: 3},
+                Counts({0b00: 0, 0b01: 1, 0b10: 2, 0b11: 3}),
                 0b00,
                 {0b00: 0, 0b01: 1, 0b10: 2, 0b11: 3},
             ),
             (
-                Counts,
-                {0b00: 0, 0b01: 1, 0b10: 2, 0b11: 3},
+                Counts({0b00: 0, 0b01: 1, 0b10: 2, 0b11: 3}),
                 0b01,
                 {0b00: 1, 0b01: 0, 0b10: 3, 0b11: 2},
             ),
             (
-                Counts,
-                {0b00: 0, 0b01: 1, 0b10: 2, 0b11: 3},
+                Counts({0b00: 0, 0b01: 1, 0b10: 2, 0b11: 3}),
                 0b10,
                 {0b00: 2, 0b01: 3, 0b10: 0, 0b11: 1},
             ),
             (
-                Counts,
-                {0b00: 0, 0b01: 1, 0b10: 2, 0b11: 3},
+                Counts({0b00: 0, 0b01: 1, 0b10: 2, 0b11: 3}),
                 0b11,
                 {0b00: 3, 0b01: 2, 0b10: 1, 0b11: 0},
             ),
-            (QuasiDistribution, {0b00: 0, 0b01: 1}, 0b00, {0b00: 0, 0b01: 1}),
-            (QuasiDistribution, {0b00: 0, 0b01: 1}, 0b01, {0b01: 0, 0b00: 1}),
-            (QuasiDistribution, {0b00: 0, 0b01: 1}, 0b10, {0b10: 0, 0b11: 1}),
-            (QuasiDistribution, {0b00: 0, 0b01: 1}, 0b11, {0b11: 0, 0b10: 1}),
+            (QuasiDistribution({0b00: 0, 0b01: 1}), 0b00, {0b00: 0, 0b01: 1}),
+            (QuasiDistribution({0b00: 0, 0b01: 1}), 0b01, {0b01: 0, 0b00: 1}),
+            (QuasiDistribution({0b00: 0, 0b01: 1}), 0b10, {0b10: 0, 0b11: 1}),
+            (QuasiDistribution({0b00: 0, 0b01: 1}), 0b11, {0b11: 0, 0b10: 1}),
             (
-                QuasiDistribution,
-                {0b00: 0, 0b01: 0.25, 0b10: 0.25, 0b11: 0.5},
+                QuasiDistribution({0b00: 0, 0b01: 0.25, 0b10: 0.25, 0b11: 0.5}),
                 0b00,
                 {0b00: 0, 0b01: 0.25, 0b10: 0.25, 0b11: 0.5},
             ),
             (
-                QuasiDistribution,
-                {0b00: 0, 0b01: 0.25, 0b10: 0.25, 0b11: 0.5},
+                QuasiDistribution({0b00: 0, 0b01: 0.25, 0b10: 0.25, 0b11: 0.5}),
                 0b01,
                 {0b01: 0, 0b00: 0.25, 0b11: 0.25, 0b10: 0.5},
             ),
             (
-                QuasiDistribution,
-                {0b00: 0, 0b01: 0.25, 0b10: 0.25, 0b11: 0.5},
+                QuasiDistribution({0b00: 0, 0b01: 0.25, 0b10: 0.25, 0b11: 0.5}),
                 0b10,
                 {0b10: 0, 0b11: 0.25, 0b00: 0.25, 0b01: 0.5},
             ),
             (
-                QuasiDistribution,
-                {0b00: 0, 0b01: 0.25, 0b10: 0.25, 0b11: 0.5},
+                QuasiDistribution({0b00: 0, 0b01: 0.25, 0b10: 0.25, 0b11: 0.5}),
                 0b11,
                 {0b11: 0, 0b10: 0.25, 0b01: 0.25, 0b00: 0.5},
             ),
         ],
     )
-    def test_bitflip_frequencies(self, frequency_type, frequencies, bitflips, expected):
+    def test_bitflip_frequencies(self, frequencies, bitflips, expected):
         """Test bitflip frequencies base functionality."""
-        frequencies = frequency_type(frequencies)
-        assert bitflip_frequencies(frequencies, bitflips) == frequency_type(expected)
+        assert bitflip_frequencies(frequencies, bitflips) == type(frequencies)(expected)
 
 
 class TestMaskFrequencies:

--- a/test/unit/quantum/results/test_frequencies.py
+++ b/test/unit/quantum/results/test_frequencies.py
@@ -9,14 +9,17 @@
 # that they have been altered from the originals.
 
 """Tests for frequency results tools."""
+from test import TYPES
+
 from numpy import sqrt
-from pytest import mark
+from pytest import mark, raises
 from qiskit.result import Counts, QuasiDistribution
 
 from pr_toolbox.quantum.results.frequencies import (
     bitflip_frequencies,
     bitmask_frequencies,
-    map_frequencies, convert_counts_to_quasi_dists,
+    convert_counts_to_quasi_dists,
+    map_frequencies,
 )
 
 
@@ -31,16 +34,12 @@ class TestMapFrequencies:
         [
             (Counts({}), lambda _: None, {}),
             (QuasiDistribution({}), lambda _: None, {}),
-
             (Counts({0: 1}), lambda _: 0, {0: 1}),
             (QuasiDistribution({0: 1}), lambda _: 0, {0: 1}),
-
             (Counts({0: 1}), lambda _: 1, {1: 1}),
             (QuasiDistribution({0: 1}), lambda _: 1, {1: 1}),
-
             (Counts({0: 1, 1: 1}), lambda _: 1, {1: 2}),
             (QuasiDistribution({0: 0.5, 1: 0.5}), lambda _: 1, {1: 1}),
-
             (Counts({0: 0, 1: 1}), lambda k: k + 1, {1: 0, 2: 1}),
             (QuasiDistribution({0: 0, 1: 1}), lambda k: k + 1, {1: 0, 2: 1}),
         ],
@@ -48,6 +47,12 @@ class TestMapFrequencies:
     def test_map_frequencies(self, frequencies, map, expected):
         """Test map frequencies base functionality."""
         assert map_frequencies(frequencies, map) == type(frequencies)(expected)
+
+    @mark.parametrize("frequencies", TYPES)
+    def test_wrong_frequency_type(self, frequencies):
+        """Test a non-FrequencyLike input."""
+        with raises(TypeError):
+            map_frequencies(frequencies, lambda _: None)
 
 
 class TestBitflipFrequencies:
@@ -105,7 +110,7 @@ class TestFrequencyConversion:
             Counts({0: 1, 1: 1}),
             Counts({0: 0, 1: 5}),
             Counts({12: 1, 13: 5, 14: 1}),
-            Counts({5: 6})
+            Counts({5: 6}),
         ],
     )
     def test_convert_counts_to_quasi_dists(self, counts):
@@ -115,4 +120,6 @@ class TestFrequencyConversion:
         assert quasi_dists.shots == counts.shots()
         if quasi_dists.shots:
             assert quasi_dists.stddev_upper_bound == sqrt(1 / quasi_dists.shots)
-        assert quasi_dists == {k: v / (quasi_dists.shots or 1) for k, v in counts.int_outcomes().items()}
+        assert quasi_dists == {
+            k: v / (quasi_dists.shots or 1) for k, v in counts.int_outcomes().items()
+        }

--- a/test/unit/quantum/results/test_frequencies.py
+++ b/test/unit/quantum/results/test_frequencies.py
@@ -53,7 +53,7 @@ class TestMapFrequencies:
             assert frequencies.shots == expected_frequencies.shots
             assert frequencies.stddev_upper_bound == expected_frequencies.stddev_upper_bound
 
-    @mark.parametrize("frequencies", TYPES)
+    @mark.parametrize("frequencies", [t for t in TYPES if not (isinstance(t, dict))])
     def test_wrong_frequency_type(self, frequencies):
         """Test a non-FrequencyLike input."""
         with raises(TypeError):

--- a/test/unit/quantum/results/test_frequencies.py
+++ b/test/unit/quantum/results/test_frequencies.py
@@ -9,7 +9,7 @@
 # that they have been altered from the originals.
 
 """Tests for frequency results tools."""
-from test import TYPES
+from test import FLOAT, INT, ITERS, NO_INTS, TYPES
 
 from numpy import sqrt
 from pytest import mark, raises
@@ -32,14 +32,19 @@ class TestMapFrequencies:
     @mark.parametrize(
         "frequencies, map, expected",
         [
+            ({}, lambda _: None, {}),
             (Counts({}), lambda _: None, {}),
             (QuasiDistribution({}), lambda _: None, {}),
+            ({0: 1}, lambda _: 0, {0: 1}),
             (Counts({0: 1}), lambda _: 0, {0: 1}),
             (QuasiDistribution({0: 1}), lambda _: 0, {0: 1}),
+            ({0: 1}, lambda _: 1, {1: 1}),
             (Counts({0: 1}), lambda _: 1, {1: 1}),
             (QuasiDistribution({0: 1}), lambda _: 1, {1: 1}),
+            ({0: 1, 1: 1}, lambda _: 1, {1: 2}),
             (Counts({0: 1, 1: 1}), lambda _: 1, {1: 2}),
             (QuasiDistribution({0: 0.5, 1: 0.5}), lambda _: 1, {1: 1}),
+            ({0: 0, 1: 1}, lambda k: k + 1, {1: 0, 2: 1}),
             (Counts({0: 0, 1: 1}), lambda k: k + 1, {1: 0, 2: 1}),
             (QuasiDistribution({0: 0, 1: 1}), lambda k: k + 1, {1: 0, 2: 1}),
         ],
@@ -56,6 +61,17 @@ class TestMapFrequencies:
     @mark.parametrize("frequencies", [t for t in TYPES if not (isinstance(t, dict))])
     def test_wrong_frequency_type(self, frequencies):
         """Test a non-FrequencyLike input."""
+        with raises(TypeError):
+            map_frequencies(frequencies, lambda _: None)
+
+    @mark.parametrize(
+        "frequencies",
+        [{t: INT} for t in NO_INTS if t not in ITERS]
+        + [{t: FLOAT} for t in NO_INTS if t not in ITERS]
+        + [{INT: t} for t in NO_INTS if not isinstance(t, float)],
+    )
+    def test_wrong_dict_entry_types(self, frequencies):
+        """Test a dict input with wrong entry types."""
         with raises(TypeError):
             map_frequencies(frequencies, lambda _: None)
 


### PR DESCRIPTION
### Summary

Refactor frequencies utilities to generalize to `QuasiDistribution`s and add further functionality to convert from `Counts` to `QuasiDistribution`s.