### PR TITLE
fix(frequencies): fix plural name in counts_to_quasi_dist

### DIFF
--- a/pr_toolbox/quantum/results/frequencies.py
+++ b/pr_toolbox/quantum/results/frequencies.py
@@ -129,7 +129,7 @@ def bitmask_frequencies(frequencies: FrequenciesLike, bitmask: int) -> Frequenci
     return map_frequencies(frequencies, lambda readout: readout & bitmask)
 
 
-def counts_to_quasi_dists(counts: Counts) -> QuasiDistribution:
+def counts_to_quasi_dist(counts: Counts) -> QuasiDistribution:
     """Infers a :class:`~qiskit.result.QuasiDistribution` from :class:`~qiskit.result.Counts`.
 
     Args:

--- a/test/unit/quantum/results/test_frequencies.py
+++ b/test/unit/quantum/results/test_frequencies.py
@@ -18,7 +18,7 @@ from qiskit.result import Counts, QuasiDistribution
 from pr_toolbox.quantum.results.frequencies import (
     bitflip_frequencies,
     bitmask_frequencies,
-    counts_to_quasi_dists,
+    counts_to_quasi_dist,
     map_frequencies,
 )
 
@@ -194,7 +194,7 @@ class TestFrequencyConversion:
     def test_wrong_counts_type(self, counts):
         """Test wrong counts types upon conversion."""
         with raises(TypeError):
-            counts_to_quasi_dists(counts)
+            counts_to_quasi_dist(counts)
 
     @mark.parametrize(
         "counts",
@@ -207,9 +207,9 @@ class TestFrequencyConversion:
             Counts({5: 6}),
         ],
     )
-    def test_convert_counts_to_quasi_dists(self, counts):
+    def test_convert_counts_to_quasi_dist(self, counts):
         """Test convert counts functionality."""
-        quasi_dists = counts_to_quasi_dists(counts)
+        quasi_dists = counts_to_quasi_dist(counts)
         assert isinstance(quasi_dists, QuasiDistribution)
         assert quasi_dists.shots == counts.shots()
         if quasi_dists.shots:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Function name `counts_to_quasi_dists` is wrong since the output is a single `QuasiDistribution`. Correct name is `counts_to_quasi_dist`.
